### PR TITLE
Mitigate renaming of quocslib.pulses.super_parameter module

### DIFF
--- a/src/quocslib/pulses/BasePulse.py
+++ b/src/quocslib/pulses/BasePulse.py
@@ -71,7 +71,7 @@ class BasePulse:
         shaping_option_dict = {"add_base_pulse": self.add_base_pulse, "add_initial_guess": self.add_initial_guess,
                                "limit_pulse": self.limit_pulse, "scale_pulse": self.scale_pulse}
         if shaping_options is None:
-            self.shaping_options = [self.add_base_pulse, self.add_initial_guess, self.limit_pulse, self.scale_pulse]
+            self.shaping_options = [self.add_base_pulse, self.add_initial_guess, self.scale_pulse, self.limit_pulse]
         else:
             self.shaping_options = []
             for op_str in shaping_options:

--- a/src/quocslib/utils/dynamicimport.py
+++ b/src/quocslib/utils/dynamicimport.py
@@ -28,8 +28,8 @@ def dynamic_import(attribute=None, module_name: str = None, class_name: str = No
     # If the attribute is already given, then just return the attribute
     if attribute is not None:
         return attribute
-    # Get the attribute       
-    import_conditions = [module_name is not None, class_name is not None]    
+    # Get the attribute
+    import_conditions = [module_name is not None, class_name is not None]
     if all(import_conditions):
         try:
             # provide backward - compatibility after renaming

--- a/src/quocslib/utils/dynamicimport.py
+++ b/src/quocslib/utils/dynamicimport.py
@@ -28,10 +28,13 @@ def dynamic_import(attribute=None, module_name: str = None, class_name: str = No
     # If the attribute is already given, then just return the attribute
     if attribute is not None:
         return attribute
-    # Get the attribute
-    import_conditions = [module_name is not None, class_name is not None]
+    # Get the attribute       
+    import_conditions = [module_name is not None, class_name is not None]    
     if all(import_conditions):
         try:
+            # provide backward - compatibility after renaming
+            module_name = module_name.replace("quocslib.pulses.super_parameter.", "quocslib.pulses.superparameter.")
+            
             attribute = getattr(importlib.import_module(module_name), class_name)
         except Exception as ex:
             print("{0}.py module does not exist or {1} is not the class in that module".format(module_name, class_name))


### PR DESCRIPTION
change of module name from quocslib.pulses.super_parameter to quocslib.pulses.superparameter broke existing experiment configurations in qcalibrate as well as schema definition, UI, etc. There is a patch necessary to make it work again.