### PR TITLE
Add the option to disable the console stream

### DIFF
--- a/Documentation/Settings_in_Optimization_Dict.md
+++ b/Documentation/Settings_in_Optimization_Dict.md
@@ -11,6 +11,7 @@ Assuming you define the settings in the form of a .json file, the general struct
 {
     "optimization_client_name": "Name_of_your_Optimization",
     "create_logfile": true,  # determines if you want to save the log-file
+    "console_info": true, # determines if you want the optimization output on the console
     "dump_format": "npz",  # format of the results file
     "algorithm_settings": {...},  # settings related to the algorithm
     "pulses": [{...}, {...}, ...],  # list of pulses and their settings
@@ -24,6 +25,8 @@ These entries are keywords but you can add more entries to the dictionary if you
 The `optimization_client_name` determines the name of the folder where the optimization results are saved. A timestamp is prepended to the name so that each optimization run generates a separate output folder. You can find the results inside of a "QuOCS_Results" folder created in the directory from where you execute the optimization.
 
 The `create_logfile` key determines if the full output of the Python terminal is saved to a log-file. If you have an optimization with many iterations this can become quite large, so you might want to  disable it once you know your optimizations are running reliably.
+
+The `console_info` key determines if the optimization output is shown in the terminal during the execution of the optimization. Indeed, if you want to run optimization in parallel, the standard output in the terminal can arise problems, so you might want to disable it once you know your optimizations are running reliably.
 
 The `dump_format` key specifies the format of the results file (best controls and some meta data). Currently you can choose between "npz" and "json". The default (if you do not give this key) is "npz".
 

--- a/src/quocslib/Optimizer.py
+++ b/src/quocslib/Optimizer.py
@@ -54,6 +54,7 @@ class Optimizer:
 
         self.interface_job_name = optimization_dict.setdefault("optimization_client_name", "run")
         self.create_logfile = optimization_dict.setdefault("create_logfile", True)
+        self.console_info = optimization_dict.setdefault("console_info", True)
         self.dump_format = optimization_dict.setdefault("dump_format", "npz")
         self.optimization_direction = optimization_dict["algorithm_settings"].setdefault("optimization_direction",
                                                                                          "minimization")
@@ -63,6 +64,7 @@ class Optimizer:
                                                        dump_attribute=BestDump,
                                                        comm_signals_list=comm_signals_list,
                                                        create_logfile=self.create_logfile,
+                                                       console_info=self.console_info,
                                                        dump_format=self.dump_format,
                                                        optimization_direction=self.optimization_direction)
 

--- a/src/quocslib/__init__.py
+++ b/src/quocslib/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-__VERSION__ = "0.0.55"
+__VERSION__ = "0.0.56"

--- a/src/quocslib/communication/AllInOneCommunication.py
+++ b/src/quocslib/communication/AllInOneCommunication.py
@@ -33,6 +33,7 @@ class AllInOneCommunication:
                  dump_attribute: callable = DummyDump,
                  comm_signals_list: [list, list, list] = None,
                  create_logfile: bool = True,
+                 console_info: bool = True,
                  dump_format: str = "npz",
                  optimization_direction: str = "minimization"):
         """
@@ -46,6 +47,8 @@ class AllInOneCommunication:
         :param AbstractHandleExit handle_exit_obj: Collect any error during the optimization and check when the
         communication is finished to communicate with the client interface
         :param [list, list, list] comm_signals_list: List containing the signals to the gui
+        :param create_logfile: Boolean to create the log file or not
+        :param console_info: Boolean to show info in the console or not
         """
         # Communication signals
         if comm_signals_list is None:
@@ -72,7 +75,7 @@ class AllInOneCommunication:
         with open(os.path.join(self.results_path, "quocs_version.txt"), "w") as version_file:
             version_file.write("QuOCS library version: {0}".format(quocslib_version))
         # Create logging object
-        self.logger = create_logger(self.results_path, self.date_time, create_logfile=create_logfile)
+        self.logger = create_logger(self.results_path, self.date_time, create_logfile=create_logfile, console_info=console_info)
         # Print function evaluation and figure of merit
         self.print_general_log = True
         # Figure of merit object

--- a/src/quocslib/tools/logger.py
+++ b/src/quocslib/tools/logger.py
@@ -20,7 +20,7 @@ import sys
 import time
 
 
-def create_logger(results_path, date_time, create_logfile=True, is_debug=False):
+def create_logger(results_path, date_time, create_logfile=True, console_info=True, is_debug=False):
     """
     Create a logger object based on the logging module. >It defines a custom format for the log messages, the date and
     printed messages and the log file name. The logger object is returned and can be used to log messages in the code.
@@ -28,6 +28,7 @@ def create_logger(results_path, date_time, create_logfile=True, is_debug=False):
     :param results_path: Path where the log file will be saved
     :param date_time: Date and time of the execution (for the log file name)
     :param create_logfile: Boolean to create the log file or not
+    :param console_info: Boolean to show info in the console or not
     :param is_debug: Boolean to activate the debug mode
     :return: logger object
     """
@@ -44,7 +45,10 @@ def create_logger(results_path, date_time, create_logfile=True, is_debug=False):
     logger.setLevel(logging.DEBUG)
     # Console handler
     console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(logging.INFO)
+    if console_info:
+        console_handler.setLevel(logging.INFO)
+    else:
+        console_handler.setLevel(logging.ERROR)
     console_handler.setFormatter(logging.Formatter(print_format))
     # Log file handler
     if create_logfile:


### PR DESCRIPTION
I've added an entry in the optimization dictionary called console_info in order to enable or disable the info stream in the terminal. If console_info=False, only the error will be shown in the terminal.